### PR TITLE
Add option to run couple script in custom venv

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -28,7 +28,7 @@ jobs:
 
     - name: Run tests
       run: |
-        pytest --cov --cov-report=xml
+        pytest --cov=pycoupler --cov-report=xml
 
     - name: Upload coverage reports to Codecov
       uses: codecov/codecov-action@v5

--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,7 @@ env/
 venv/
 *JB.py
 
-pycoupler.egg-info/
+*.egg-info/
 build/
+.coverage
+.pytest_cache/

--- a/pycoupler/run.py
+++ b/pycoupler/run.py
@@ -88,6 +88,7 @@ def submit_lpjml(
     blocking=None,
     option=None,
     couple_to=None,
+    venv_path=None,
 ):
     """Submit LPJmL run to Slurm using `lpjsubmit` and a generated
     (class LpjmlConfig) config file. Provide arguments for Slurm sbatch
@@ -122,6 +123,8 @@ def submit_lpjml(
     :type option: str/list
     :param couple_to: path to program/model/script LPJmL should be coupled to
     :type couple_to: str
+    :param venv_path: path to a venv to run the coupled script in. This should be the path to the top folder of the venv. If not set, `python3` in PATH is used.
+    :type venv_path: str, optional
     :return: return the submitted jobs id if submitted successfully.
     :rtype: str
     """
@@ -166,13 +169,19 @@ def submit_lpjml(
 
     # run in coupled mode and pass coupling program/model
     if couple_to:
+        python_path = "python3"
+        if venv_path:
+            python_path = os.path.join(venv_path, "bin/python")
+            if not os.path.isfile(python_path):
+                raise FileNotFoundError("venv path contains no python binary at '" + python_path + "'.")
+
         bash_script = f"""#!/bin/bash
 
 # Define the path to the config file
 config_file="{config_file}"
 
 # Call the Python script with the config file as an argument
-python3 {couple_to} $config_file
+{python_path} {couple_to} $config_file
 """
 
         couple_file = f"{output_path}/inseeds.sh"

--- a/pycoupler/run.py
+++ b/pycoupler/run.py
@@ -173,7 +173,9 @@ def submit_lpjml(
         if venv_path:
             python_path = os.path.join(venv_path, "bin/python")
             if not os.path.isfile(python_path):
-                raise FileNotFoundError("venv path contains no python binary at '" + python_path + "'.")
+                raise FileNotFoundError(
+                    "venv path contains no python binary at '" + python_path + "'."
+                )
 
         bash_script = f"""#!/bin/bash
 
@@ -195,6 +197,9 @@ config_file="{config_file}"
         cmd.extend(["-couple", couple_file])
 
     cmd.extend([str(ntasks), config_file])
+
+    # Intialize submit_status in higher scope
+    submit_status = None
     # set LPJROOT to model_path to be able to call lpjsubmit
     try:
         os.environ["LPJROOT"] = config.model_path
@@ -209,7 +214,9 @@ config_file="{config_file}"
             del os.environ["LPJROOT"]
 
     # print stdout and stderr if not successful
-    if submit_status.returncode == 0:
+    if submit_status is None:
+        raise Exception("Process was not submitted.")
+    elif submit_status.returncode == 0:
         print(submit_status.stdout.decode("utf-8"))
     else:
         print(submit_status.stdout.decode("utf-8"))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dependencies = [
 dev = [
     "pytest",
     "pytest-cov",
+    "pytest-subprocess",
     "sphinx",
     "black",
     "flake8"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,14 +15,6 @@ def test_path():
 
 
 @pytest.fixture()
-def mock_venv(tmp_path_factory):
-    venv = tmp_path_factory.mktemp("venv")
-    (venv / "bin").mkdir()
-    (venv / "bin" / "python").touch()
-    return venv
-
-
-@pytest.fixture()
 def sim_path(tmp_path_factory):
     sim_fn = tmp_path_factory.mktemp("sim")
     return sim_fn

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 import os
 import pytest
+import json
 
 
 def get_test_path():
@@ -11,6 +12,38 @@ def get_test_path():
 def test_path():
     """Fixture for the test path."""
     return get_test_path()
+
+
+@pytest.fixture()
+def mock_venv(tmp_path_factory):
+    venv = tmp_path_factory.mktemp("venv")
+    (venv / "bin").mkdir()
+    (venv / "bin" / "python").touch()
+    return venv
+
+
+@pytest.fixture()
+def sim_path(tmp_path_factory):
+    sim_fn = tmp_path_factory.mktemp("sim")
+    return sim_fn
+
+
+@pytest.fixture()
+def model_path(tmp_path_factory):
+    model_fn = tmp_path_factory.mktemp("model")
+    return model_fn
+
+
+@pytest.fixture()
+def config_coupled(sim_path, model_path, test_path):
+    new_config = sim_path / "config_coupled.json"
+    with open(f"{test_path}/data/config_coupled_test.json") as conf:
+        conf_d = json.load(conf)
+        conf_d["model_path"] = str(model_path)
+        conf_d["sim_path"] = str(sim_path)
+        with new_config.open("w") as f:
+            json.dump(conf_d, f)
+            return str(new_config)
 
 
 def pytest_configure(config):

--- a/tests/test_couple.py
+++ b/tests/test_couple.py
@@ -64,7 +64,47 @@ def test_lpjml_coupler(test_path):
 
     assert (
         repr(lpjml_coupler)
-        == f"<pycoupler.LPJmLCoupler>\nSimulation:  (version: 3, localhost:<none>)\n  * sim_year   2050\n  * ncell      2\n  * ninput     1\nConfiguration:\n  Settings:      lpjml v5.8\n    (general)\n    * sim_name   coupled_test\n    * firstyear  2001\n    * lastyear   2050\n    * startgrid  27410\n    * endgrid    27411\n    * landuse    yes\n    (changed)\n    * model_path           LPJmL_internal\n    * sim_path             {test_path}/data/\n    * outputyear           2022\n    * output_metafile      True\n    * write_restart        False\n    * nspinup              0\n    * float_grid           True\n    * restart_filename     restart/restart_historic_run.lpj\n    * outputyear           2022\n    * radiation            cloudiness\n    * fix_co2              True\n    * fix_co2_year         2018\n    * fix_climate          True\n    * fix_climate_cycle    11\n    * fix_climate_year     2013\n    * river_routing        False\n    * tillage_type         read\n    * residue_treatment    fixed_residue_remove\n    * double_harvest       False\n    * intercrop            True\n    * sim_path             {test_path}/data/\n  Coupled model:        copan:CORE\n    * start_coupling    2023\n    * input (coupled)   ['with_tillage']\n    * output (coupled)  ['grid', 'pft_harvestc', 'cftfrac', 'soilc_agr_layer', 'hdate', 'country', 'region']\n  "  # noqa
+        == f"""<pycoupler.LPJmLCoupler>
+Simulation:  (version: 3, localhost:<none>)
+  * sim_year   2050
+  * ncell      2
+  * ninput     1
+Configuration:
+  Settings:      lpjml v5.8
+    (general)
+    * sim_name   coupled_test
+    * firstyear  2001
+    * lastyear   2050
+    * startgrid  27410
+    * endgrid    27411
+    * landuse    yes
+    (changed)
+    * model_path           LPJmL_internal
+    * sim_path             {test_path}/data/
+    * outputyear           2022
+    * output_metafile      True
+    * write_restart        False
+    * nspinup              0
+    * float_grid           True
+    * restart_filename     restart/restart_historic_run.lpj
+    * outputyear           2022
+    * radiation            cloudiness
+    * fix_co2              True
+    * fix_co2_year         2018
+    * fix_climate          True
+    * fix_climate_cycle    11
+    * fix_climate_year     2013
+    * river_routing        False
+    * tillage_type         read
+    * residue_treatment    fixed_residue_remove
+    * double_harvest       False
+    * intercrop            True
+    * sim_path             {test_path}/data/
+  Coupled model:        copan:CORE
+    * start_coupling    2023
+    * input (coupled)   ['with_tillage']
+    * output (coupled)  ['grid', 'pft_harvestc', 'cftfrac', 'soilc_agr_layer', 'hdate', 'country', 'region']
+  """  # noqa
     )
 
 

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -1,5 +1,6 @@
 from pycoupler.run import submit_lpjml
 import pytest
+from subprocess import CalledProcessError
 
 
 class TestLpjSubmit:
@@ -10,16 +11,34 @@ class TestLpjSubmit:
     couple_script = "/some/path/to/script.py"
 
     @pytest.fixture(autouse=True)
-    def mock_lpjsubmit(self, fp):
-        # Allow other commands, such as chmod
-        fp.allow_unregistered(True)
+    def mock_lpjsubmit(self, fp, request):
+        # We expect chmod to actually modify permissions
+        fp.pass_command([fp.program("chmod"), "+x", fp.any(min=1, max=1)])
+        if hasattr(request, "param") and request.param == "no mocking":
+            return
         # Register a fake process for lpjsubmit (see https://pytest-subprocess.readthedocs.io/en/latest/usage.html#non-exact-command-matching)
-        fp.register(
+        return fp.register(
             [fp.program("lpjsubmit"), fp.any()],
             stdout="Mock lpjsubmit\nSubmitted batch job 42\nsome stuff",
+            returncode=(
+                1
+                if hasattr(request, "param") and request.param == "non-zero errorcode"
+                else 0
+            ),
         )
 
-    @pytest.fixture(autouse=True, params=[True, False], ids=["with_venv", "no_venv"])
+    @pytest.fixture()
+    def mock_venv(self, tmp_path_factory, request):
+        if hasattr(request, "param") and request.param == "none":
+            return None
+        else:
+            venv = tmp_path_factory.mktemp("venv")
+            if not hasattr(request, "param") or request.param != "broken":
+                (venv / "bin").mkdir()
+                (venv / "bin" / "python").touch()
+            return str(venv)
+
+    @pytest.fixture(autouse=True)
     def submit(
         self,
         mock_venv,
@@ -34,11 +53,33 @@ class TestLpjSubmit:
             ntasks=self.ntasks,
             wtime=self.wtime,
             couple_to=self.couple_script,
-            venv_path=str(mock_venv) if request.param else None,
+            venv_path=mock_venv,
         )
 
     def test_job_id(self, submit):
         assert submit == "42"
+
+    @pytest.mark.parametrize(
+        "mock_lpjsubmit",
+        [
+            pytest.param(
+                "no mocking",
+                marks=pytest.mark.xfail(
+                    raises=pytest.raises(Exception, match=r"Process was not submitted.")
+                ),
+            ),
+            pytest.param(
+                "non-zero errorcode",
+                marks=pytest.mark.xfail(
+                    raises=pytest.raises(CalledProcessError, match=r"status 1")
+                ),
+            ),
+        ],
+        indirect=True,
+    )
+    def test_lpjsubmit_error_cases(self, mock_lpjsubmit):
+        # The test does nothing, we expect the fail in the fixtures
+        pass
 
     def test_command(self, sim_path, config_coupled, fp):
         run_script_path = sim_path / "output/coupled_test/inseeds.sh"
@@ -65,8 +106,16 @@ class TestLpjSubmit:
             == 1
         ), "lpjsubmit should be called exactly once with correct parameters"
 
+    @pytest.mark.parametrize(
+        "mock_venv",
+        [
+            "working",
+            pytest.param("broken", marks=pytest.mark.xfail(raises=FileNotFoundError)),
+            "none",
+        ],
+        indirect=True,
+    )
     def test_run_script(self, sim_path, config_coupled, mock_venv, request):
-
         run_script_path = sim_path / "output/coupled_test/inseeds.sh"
         assert run_script_path.is_file(), "run script should have been created"
         assert (
@@ -81,6 +130,6 @@ class TestLpjSubmit:
 config_file="{config_coupled}"
 
 # Call the Python script with the config file as an argument
-{f"{str(mock_venv)}/bin/python" if "with_venv" in request.node.name else "python3"} {self.couple_script} $config_file
+{f"{mock_venv}/bin/python" if mock_venv else "python3"} {self.couple_script} $config_file
 """
             )

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -1,0 +1,86 @@
+from pycoupler.run import submit_lpjml
+import pytest
+
+
+class TestLpjSubmit:
+    group = "copan"
+    sclass = "short"
+    ntasks = 256
+    wtime = "00:16:10"
+    couple_script = "/some/path/to/script.py"
+
+    @pytest.fixture(autouse=True)
+    def mock_lpjsubmit(self, fp):
+        # Allow other commands, such as chmod
+        fp.allow_unregistered(True)
+        # Register a fake process for lpjsubmit (see https://pytest-subprocess.readthedocs.io/en/latest/usage.html#non-exact-command-matching)
+        fp.register(
+            [fp.program("lpjsubmit"), fp.any()],
+            stdout="Mock lpjsubmit\nSubmitted batch job 42\nsome stuff",
+        )
+
+    @pytest.fixture(autouse=True, params=[True, False], ids=["with_venv", "no_venv"])
+    def submit(
+        self,
+        mock_venv,
+        sim_path,
+        config_coupled,
+        request,
+    ):
+        return submit_lpjml(
+            config_coupled,
+            group=self.group,
+            sclass=self.sclass,
+            ntasks=self.ntasks,
+            wtime=self.wtime,
+            couple_to=self.couple_script,
+            venv_path=str(mock_venv) if request.param else None,
+        )
+
+    def test_job_id(self, submit):
+        assert submit == "42"
+
+    def test_command(self, sim_path, config_coupled, fp):
+        run_script_path = sim_path / "output/coupled_test/inseeds.sh"
+        assert (
+            fp.call_count(
+                [
+                    fp.program("lpjsubmit"),
+                    "-group",
+                    self.group,
+                    "-class",
+                    self.sclass,
+                    "-o",
+                    fp.any(max=1, min=1),
+                    "-e",
+                    fp.any(max=1, min=1),
+                    "-wtime",
+                    self.wtime,
+                    "-couple",
+                    str(run_script_path),
+                    str(self.ntasks),
+                    config_coupled,
+                ]
+            )
+            == 1
+        ), "lpjsubmit should be called exactly once with correct parameters"
+
+    def test_run_script(self, sim_path, config_coupled, mock_venv, request):
+
+        run_script_path = sim_path / "output/coupled_test/inseeds.sh"
+        assert run_script_path.is_file(), "run script should have been created"
+        assert (
+            run_script_path.stat().st_mode & 0o0100
+        ), "run script should be executable"
+        with run_script_path.open("r") as f:
+            assert (
+                f.read()
+                == f"""#!/bin/bash
+
+# Define the path to the config file
+config_file="{config_coupled}"
+
+# Call the Python script with the config file as an argument
+{f"{str(mock_venv)}/bin/python" if "with_venv" in request.node.name else "python3"} {self.couple_script} $config_file
+"""
+            )


### PR DESCRIPTION
This pull requests adds the option to run the coupling scripts in a custom python venv. 
I have tested it on the cluster with LPJmL 5.9.7